### PR TITLE
Update facebook/php-business-sdk requirement from ^3.3 || ^4.0 || ^5.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=7.1.13",
-        "facebook/php-business-sdk": "^3.3 || ^4.0 || ^5.0 || ^7.0"
+        "facebook/php-business-sdk": "^3.3 || ^4.0 || ^5.0 || ^7.0 || ^9.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",


### PR DESCRIPTION
…0 || ^7.0 to ^3.3 || ^4.0 || ^5.0 || ^7.0 || ^9.0

Updates the requirements on [facebook/php-business-sdk](https://github.com/facebook/facebook-php-business-sdk) to permit the latest version.
- [Release notes](https://github.com/facebook/facebook-php-business-sdk/releases)
- [Changelog](https://github.com/facebook/facebook-php-business-sdk/blob/master/CHANGELOG.md)
- [Commits](https://github.com/facebook/facebook-php-business-sdk/commits/9.0.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>